### PR TITLE
[ISSUE PORT] "Add nCine to the list of game engines" from leereilly/games

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,7 @@ A selection of major game studios, publishers, etc. using GitHub:
 * [Matter.js](https://github.com/liabru/matter-js) - Matter.js is a JavaScript 2D rigid body physics engine for the web.
 * [melonJS](https://github.com/melonjs/melonJS) - HTML5 game framework for 2D games.
 * [MonoGame](https://github.com/mono/MonoGame) - XNA Implementation for Mono based platforms (supports iOS, Android, Linux, and started work on PS Suite and NaCli ).
+* [nCine](https://github.com/nCine/nCine) - A cross-platform 2D game engine with an emphasis on performance, written in C++11 and optionally scriptable in Lua.
 * [Oimo.js](https://github.com/lo-th/Oimo.js) - Lightweight 3d physics engine for javascript.
 * [OpenRTS](https://github.com/methusalah/OpenRTS) - Real-Time Strategy game 3D engine coded in java 7.
 * [Oxygine](https://github.com/oxygine/oxygine-framework) - C++ engine and framework for 2D games on iOS, Android, Windows, Linux and Mac.


### PR DESCRIPTION
In https://api.github.com/repos/leereilly/games/pulls/573 they wrote: 
> Please consider merging this pull request in order to add [nCine](https://ncine.github.io/) to the list of game engines that can be found on GitHub.